### PR TITLE
Fix for missing method in Android's JSON library

### DIFF
--- a/src/org/loklak/objects/MessageEntry.java
+++ b/src/org/loklak/objects/MessageEntry.java
@@ -24,6 +24,7 @@ package org.loklak.objects;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.loklak.tools.JsonCompatHelper;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -458,11 +459,11 @@ public class MessageEntry extends AbstractIndexEntry implements ObjectEntry {
         if (this.provider_hash != null && this.provider_hash.length() > 0) json.put("provider_hash", this.provider_hash);
         json.put("retweet_count", this.retweet_count);
         json.put("favourites_count", this.favourites_count); // there is a slight inconsistency here in the plural naming but thats how it is noted in the twitter api
-        json.put("images", this.images);
+        JsonCompatHelper.put(json, "images", this.images);
         json.put("images_count", this.images.size());
-        json.put("audio", this.audio);
+        JsonCompatHelper.put(json, "audio", this.audio);
         json.put("audio_count", this.audio.size());
-        json.put("videos", this.videos);
+        JsonCompatHelper.put(json, "videos", this.videos);
         json.put("videos_count", this.videos.size());
         json.put("place_name", this.place_name);
         json.put("place_id", this.place_id);

--- a/src/org/loklak/tools/JsonCompatHelper.java
+++ b/src/org/loklak/tools/JsonCompatHelper.java
@@ -1,0 +1,51 @@
+/**
+ *  JsonCompatHelper
+ *  Copyright 06.06.2016 by Marc Nause, @nause_marc
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; wo even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program in the file lgpl21.txt
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.loklak.tools;
+
+import java.util.Collection;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * Provides workaround methods for different JSONObject implementations in the
+ * original json.org library and the code include in Android.
+ */
+public class JsonCompatHelper {
+
+  private static boolean hasCollectionMethod;
+  static {
+    try {
+      hasCollectionMethod = JSONObject.class.getMethod("put", new Class[] { String.class, Collection.class }) != null;
+    } catch (NoSuchMethodException | SecurityException e) {
+      hasCollectionMethod = false;
+    }
+  }
+
+  public static JSONObject put(final JSONObject jsonObject, final String key, final Collection<?> value) {
+
+    if (hasCollectionMethod) {
+      return jsonObject.put(key, value);
+    } else {
+      return jsonObject.put(key, new JSONArray(value));
+    }
+  }
+
+}


### PR DESCRIPTION
This should fix issue [https://github.com/loklak/loklakj_lib/issues/1](https://github.com/loklak/loklakj_lib/issues/1).

I added a class which checks if the method exists via reflection. If it does, it will be used, if it does not, a workaround (basically the same which is done in original method) is used.

I was able to send data to the backend with [https://github.com/loklak/loklak_wok_android](https://github.com/loklak/loklak_wok_android) using loklakj compiled with the changes in this pull request.
